### PR TITLE
Test: empty-build carryforward (Layer 1)

### DIFF
--- a/empty-build-cf-028.md
+++ b/empty-build-cf-028.md
@@ -1,0 +1,3 @@
+# Empty-build carry-forward test (Layer 1)
+
+Non-coverable change to exercise the no-coverage path; should yield a vacuous-pass patch.


### PR DESCRIPTION
Throwaway PR to validate the native all-null marker + done --carryforward=<flags> on the Enterprise-OnPrem demo. Non-coverable change only.